### PR TITLE
fixed redirect loop

### DIFF
--- a/lib/rack-canonical-host.rb
+++ b/lib/rack-canonical-host.rb
@@ -15,9 +15,11 @@ module Rack # :nodoc:
     end
 
     def url(env)
-      if (host = host(env)) && env['SERVER_NAME'] != host
-        url = Rack::Request.new(env).url
-        url.sub(%r{\A(https?://)(.*?)(:\d+)?(/|$)}, "\\1#{host}\\3/")
+      if (host = host(env))
+        request = Rack::Request.new(env)
+        if request.host != host
+          request.url.sub(%r{\A(https?://)(.*?)(:\d+)?(/|$)}, "\\1#{host}\\3/")
+        end
       end
     end
     private :url


### PR DESCRIPTION
fixed redirect loop when the hostname is not in SERVER_NAME (for example with a reverse proxy)

I used Rack::Request#host instead: https://github.com/rack/rack/blob/master/lib/rack/request.rb#L86
