### PR TITLE
Add Content-Type header

### DIFF
--- a/lib/rack-canonical-host.rb
+++ b/lib/rack-canonical-host.rb
@@ -8,7 +8,7 @@ module Rack # :nodoc:
 
     def call(env)
       if url = url(env)
-        [301, { 'Location' => url }, ['Redirecting...']]
+        [301, { 'Location' => url, 'Content-Type' => 'text/html' }, ['Redirecting...']]
       else
         @app.call(env)
       end


### PR DESCRIPTION
This patch adds a Content-Type header to redirects, since without one Rack::Lint will throw an exception.
