### PR TITLE
Add :force_ssl option for ensuring https

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ use Rack::CanonicalHost, 'example.com', if: /.*\.example\.com/
 use Rack::CanonicalHost, 'example.ru', if: /.*\.example\.ru/
 ```
 
+If you'd like to enforce the use of HTTPS, use the `:force_ssl` option:
+
+``` ruby
+use Rack::CanonicalHost, 'example.com', force_ssl: true
+```
+
+In this case, requests like `http://example.com` will be redirected to
+`https://example.com`.
+
 
 ## Contributing
 

--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -117,6 +117,34 @@ describe Rack::CanonicalHost do
 
     end
 
+    context 'with :force_ssl option' do
+      let(:app) { build_app('example.com', :force_ssl => true) }
+
+      context 'with a non-ssl request' do
+        let(:url) { 'http://example.com/full/path' }
+        it { should be_redirect.to('https://example.com/full/path') }
+      end
+
+      context 'with an ssl request' do
+        let(:url) { 'https://example.com/full/path' }
+        it { should_not be_redirect }
+      end
+
+      context 'when host is not set' do
+        let(:app) { build_app(nil, :force_ssl => true) }
+        let(:url) { 'http://example.com/full/path' }
+
+        it { should be_redirect.to('https://example.com/full/path') }
+      end
+
+      context 'when :forse_ssl is false' do
+        let(:app) { build_app('example.com', :force_ssl => false) }
+        let(:url) { 'http://example.com/full/path' }
+
+        it { should_not be_redirect }
+      end
+    end
+
     context 'with a block' do
       let(:app) { build_app { 'example.com' } }
 


### PR DESCRIPTION
I ran into a use-case where I needed to redirect the following to the
(https://www) version of the url:
http://example.com
https://example.com
http://www.example.com
https://www.example.com

In the first case this would take two redirects, which is not the
end of the world. However, I figured since I was already using this
gem I'd check for an option I could pass that would ensure the
desired URI scheme while it was ensuring the desired host. Since there
wasn't one, I built it out (including specs). It's a very minor option
and is backwards compatible (doesn't force a redirect if the option
is missing, malformed, or if scheme is already correct). It does toe
the line of the single responsibility principle, but I think it makes
a great deal of sense to check both the scheme and host in one shot.
