### PR TITLE
Enable querystring manipulation via :query_values option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ use Rack::CanonicalHost, 'example.com', force_ssl: true
 In this case, requests like `http://example.com` will be redirected to
 `https://example.com`.
 
+If you'd like to put something in the querystring, perhaps so that the destination host can be sure that it received a redirect, use the `:query_values` option:
+
+```ruby
+use Rack::CanonicalHost, 'example.com', query_values: {redirected: 1}
+# your-site.com/page will redirect to example.com/page?redirected=1
+```
 
 ## Contributing
 

--- a/lib/rack/canonical_host/redirect.rb
+++ b/lib/rack/canonical_host/redirect.rb
@@ -20,6 +20,7 @@ module Rack
         @force_ssl = options[:force_ssl]
         @ignore = Array(options[:ignore])
         @if = Array(options[:if])
+        @query_values = options[:query_values]
       end
 
       def canonical?
@@ -60,6 +61,7 @@ module Rack
         request_uri.tap { |uri|
           uri.host = @host if @host
           uri.scheme = "https" if @force_ssl
+          uri.query_values = (uri.query_values || {}).update(@query_values) if @query_values
         }.to_s
       end
 

--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -145,6 +145,24 @@ describe Rack::CanonicalHost do
       end
     end
 
+    context 'with :query_values option' do
+      let(:app) { build_app('example.com', :query_values => {:name => :value, "key" => 123})}
+      
+      context 'with plain requests' do
+        ['http://my-site.com', 'http://my-site.com/', 'http://my-site.com/?'].each do |url|
+          let(:url) { url }
+          it { should be_redirect.to('http://example.com/?key=123&name=value') }
+        end
+      end
+      
+      context 'with existing query strings' do
+        ['http://my-site.com?a=b', 'http://my-site.com/?a=b', 'http://my-site.com/?a=b&'].each do |url|
+          let(:url) { url }
+          it { should be_redirect.to('http://example.com/?a=b&key=123&name=value') }
+        end
+      end
+    end
+
     context 'with a block' do
       let(:app) { build_app { 'example.com' } }
 


### PR DESCRIPTION
I'm moving a site from one URL to another, and I'd like to let my users know when they've been automatically redirected using the gem.

This mod allows the use of a :query_values option - the browser gets redirected to a URL that preserves the original querystring (if any), but includes any specified in the option.
