### PR TITLE
Add specs for X-Forwarded-Host request recognition.

### DIFF
--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -54,6 +54,23 @@ describe Rack::CanonicalHost do
       include_context 'a matching request'
     end
 
+    context 'with an X-Forwarded-Host' do
+      let(:app) { build_app('example.com') }
+      let(:url) { 'http://proxied.url/full/path' }
+
+      context 'which matches the canonical host' do
+        let(:env) { Rack::MockRequest.env_for(url, 'HTTP_X_FORWARDED_HOST' => 'example.com:80') }
+
+        include_context 'a matching request'
+      end
+
+      context 'which does not match the canonical host' do
+        let(:env) { Rack::MockRequest.env_for(url, 'HTTP_X_FORWARDED_HOST' => 'www.example.com:80') }
+
+        include_context 'a non-matching request'
+      end
+    end
+
     context 'without any options' do
       let(:app) { build_app('example.com') }
 


### PR DESCRIPTION
This is a pull request to test for and verify tylerhunt/rack-canonical-host#14.

It appears as though [Rack should recognize](https://github.com/rack/rack/commit/fb32ff74f1e68650b7b4fa9889d277ef1fd30380) the `X-Forwarded-Host` header and transparently use it for the `Rack::Request#host` value (since Dec 2009). Since this library is using `Rack::Request` to parse the request environment and capture the `url`, it _should_ be properly recognized and correctly redirect or allow.

This pull request simply adds specs to verify and ensure the functionality.
