### PR TITLE
Scope the addressable dependency

### DIFF
--- a/rack-canonical-host.gemspec
+++ b/rack-canonical-host.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |gem|
   gem.homepage = 'http://github.com/tylerhunt/rack-canonical-host'
   gem.author = 'Tyler Hunt'
 
-  gem.add_dependency 'addressable'
+  gem.add_dependency 'addressable', '> 0', '< 3'
   gem.add_dependency 'rack', '~> 1.0'
   gem.add_development_dependency 'rspec', '~> 3.0'
 


### PR DESCRIPTION
Just for the sake of paranoia. I manually tested addressable against the original `0.1.0` release, the latest `0.1.x` release, the latest `1.x` release, and the latest `2.x` release. Addressable is apparently the most stable library ever created in Ruby, because they all worked (or this is just not using much of it! :grinning:).  So, canonical appears to work with all released versions of addressable, ever. But, I added a cap for a `3.x` release to at least ensure that it gets properly tested.
