### PR TITLE
Memoize the request_uri construction for subsequent calls

### DIFF
--- a/lib/rack/canonical_host/redirect.rb
+++ b/lib/rack/canonical_host/redirect.rb
@@ -64,7 +64,7 @@ module Rack
       end
 
       def request_uri
-        Addressable::URI.parse(Rack::Request.new(@env).url)
+        @request_uri ||= Addressable::URI.parse(Rack::Request.new(@env).url)
       end
     end
   end


### PR DESCRIPTION
The `Redirect` object makes fairly liberal use of a local `request_uri` method. However, that method is not memoized and creates new Addressable objects which each query just to pull some attribute off of the URI object.  Since the entire `Redirect` instance is stateful and seemingly intended to be immutable, I've memoized the `request_uri` call here.
