### PR TITLE
Normalize redirect URL

### DIFF
--- a/lib/rack/canonical_host/redirect.rb
+++ b/lib/rack/canonical_host/redirect.rb
@@ -69,7 +69,7 @@ module Rack
       def new_url
         uri = request_uri.dup
         uri.host = host
-        uri.to_s
+        uri.normalize.to_s
       end
 
       def request_uri

--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -145,5 +145,18 @@ describe Rack::CanonicalHost do
         include_context 'matching and non-matching requests'
       end
     end
+
+    context 'with URL containing JavaScript XSS' do
+      let(:url) { 'http://subdomain.example.net/full/path' }
+      let(:env) do
+        Rack::MockRequest.env_for(url).tap do |env|
+          env[Rack::QUERY_STRING] = '"><script>alert(73541);</script>'
+        end
+      end
+
+      let(:app) { build_app('example.com') }
+
+      it { should be_redirect.to('http://example.com/full/path?%22%3E%3Cscript%3Ealert(73541)%3B%3C/script%3E') }
+    end
   end
 end


### PR DESCRIPTION
+ Rack::CanonicalHost::Redirect#new_url returns normalized URL
+ Add spec for URL containing JavaScript XSS

I happly used this gem. Suddenly a PCI scanning report hit my inbox complaining that my little app was vulnerable to some "Redirection Page Cross-Site Scripting Attacks". I tracked the problem down to the body of the redirect where the redirect URL gets injected to. This new URL needs to be escaped to solve this issue.