### PR TITLE
Use the new Travis CI container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 script: bundle exec rspec
+sudo: false
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
This should provide faster builds and enable the dependency caching for public projects.