### PR TITLE
Add a protocol option

### DIFF
--- a/lib/rack/canonical_host/redirect.rb
+++ b/lib/rack/canonical_host/redirect.rb
@@ -18,6 +18,7 @@ module Rack
       def initialize(env, host, options={})
         self.env = env
         self.host = host
+        self.protocol = options[:protocol]
         self.ignore = Array(options[:ignore])
         self.conditions = Array(options[:if])
       end
@@ -37,6 +38,7 @@ module Rack
       attr_accessor :host
       attr_accessor :ignore
       attr_accessor :conditions
+      attr_accessor :protocol
 
     private
 
@@ -69,6 +71,7 @@ module Rack
       def new_url
         uri = request_uri.dup
         uri.host = host
+        uri.scheme = protocol unless protocol.nil?
         uri.normalize.to_s
       end
 

--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -102,6 +102,15 @@ describe Rack::CanonicalHost do
       end
     end
 
+    context 'with :protocol option set to https' do
+      let(:app) { build_app('example.com', :protocol => 'https') }
+
+      context 'with a request to some path without http' do
+        let(:url) { 'http://example.net/full/path' }
+        it { should be_redirect.to('https://example.com/full/path') }
+      end
+    end
+
     context 'with :if option' do
 
       let(:app) { build_app('example.com', :if => 'www.example.net') }


### PR DESCRIPTION
Hello,

I recently had to move `http://www.lewagon.org` to `https://www.lewagon.com`. Before this change, I had two 301 (one from `.org` to `.com`, then one from `http` to `https`).

I guess other people might have this need!

It's running in production for [https://www.lewagon.com](https://www.lewagon.com) ([source code](https://github.com/lewagon/www/blob/master/Gemfile#L15))!