### PR TITLE
Change dependency restriction to allow rack 2

### DIFF
--- a/rack-canonical-host.gemspec
+++ b/rack-canonical-host.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.author = 'Tyler Hunt'
 
   gem.add_dependency 'addressable', '> 0', '< 3'
-  gem.add_dependency 'rack', '~> 1.0'
+  gem.add_dependency 'rack', ['>= 1.0.0', '< 3']
   gem.add_development_dependency 'rspec', '~> 3.0'
 
   gem.files = `git ls-files`.split($\)


### PR DESCRIPTION
Open up the dependency restriction on rack to allow for rack 2.0.0. This will allow the gem to run in Rails 5 projects. I ran the specs using rack 2.0.0alpha and they all passed. 