### PR TITLE
Support :cache_expiry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ use Rack::CanonicalHost, 'example.com', if: /.*\.example\.com/
 use Rack::CanonicalHost, 'example.ru', if: /.*\.example\.ru/
 ```
 
+To avoid browsers indefinitely caching a 301 redirect, it's a sensible idea to
+set an expiry on each redirect, to hedge against the chance you need to change
+that redirect in the future.
+
+By default
+
+```ruby
+# Browsers will cache host redirects for up to one hour
+use Rack::CanonicalHost, 'example.com'
+
+# Browsers will cache host redirects for up to 42 seconds
+use Rack::CanonicalHost, 'example.com', cache_expiry: 42
+
+# Browsers will cache host redirects indefinitely (not recommended)
+use Rack::CanonicalHost, 'example.com', cache_expiry: false
+
+# Specify a custom value for the Cache-Control header
+use Rack::CanonicalHost, 'example.com', cache_expiry: 'no-cache'
+```
+
 ## Contributing
 
   1. Fork it

--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -35,6 +35,10 @@ describe Rack::CanonicalHost do
         expect(inner_app).to_not receive(:call)
         subject
       end
+
+      it 'includes a cache expiry' do
+        expect(subject).to have_header('Cache-Control').with('max-age=3600')
+      end
     end
   end
 
@@ -132,6 +136,34 @@ describe Rack::CanonicalHost do
         it { should_not be_redirect }
       end
 
+    end
+
+    context 'with a :cache_expiry option' do
+      let(:url) { 'http://subdomain.example.net/full/path' }
+
+      context 'that is a number' do
+        let(:app) { build_app('example.com', :cache_expiry => 42) }
+
+        it 'is treated as the max-age value' do
+          expect(subject).to have_header('Cache-Control').with('max-age=42')
+        end
+      end
+
+      context 'that is a string' do
+        let(:app) { build_app('example.com', :cache_expiry => 'no-cache') }
+
+        it 'passes the value to the Cache-Control header' do
+          expect(subject).to have_header('Cache-Control').with('no-cache')
+        end
+      end
+
+      context 'that is false' do
+        let(:app) { build_app('example.com', :cache_expiry => false) }
+
+        it 'disables the Cache-Control header' do
+          expect(subject).not_to have_header('Cache-Control')
+        end
+      end
     end
 
     context 'with a block' do

--- a/spec/support/matchers/have_header.rb
+++ b/spec/support/matchers/have_header.rb
@@ -1,0 +1,52 @@
+module HaveHeader
+  class Matcher
+    attr :headers
+    attr :expected_header
+    attr :expected_value
+
+    def initialize(expected_header)
+      @expected_header = expected_header
+    end
+
+    def matches?(response)
+      _, @headers, _ = response
+
+      if expected_value
+        actual_header == expected_value
+      else
+        actual_header
+      end
+    end
+
+    def with(expected_value)
+      @expected_value = expected_value
+      self
+    end
+
+    def actual_header
+      headers[expected_header]
+    end
+
+    def description
+      sentence = "have header #{expected_header.inspect}"
+      sentence << " with #{expected_value.inspect}" if expected_value
+      sentence << ", got:\n #{headers.inspect}"
+    end
+
+    def failure_message
+      "Expected response to #{description}"
+    end
+
+    def failure_message_when_negated
+      "Did not expect response to #{description}"
+    end
+  end
+
+  def have_header(name)
+    Matcher.new(name)
+  end
+end
+
+RSpec.configure do |config|
+  config.include(HaveHeader)
+end


### PR DESCRIPTION
To avoid browsers indefinitely caching a 301 redirect, it's a sensible idea to set an expiry on each redirect, to hedge against the chance you need to change that redirect in the future.

This change adds a new option, `:cache_expiry`, that specifies the maximum duration, in seconds, a browser is allowed to cache the redirect. By default, it is set to one hour (3,600 seconds).

Usage:

```ruby
# Browsers will cache host redirects for up to one hour
use Rack::CanonicalHost, 'example.com'

# Browsers will cache host redirects for up to 42 seconds
use Rack::CanonicalHost, 'example.com', cache_expiry: 42

# Browsers will cache host redirects indefinitely (not recommended)
use Rack::CanonicalHost, 'example.com', cache_expiry: false

# Specify a custom value for the Cache-Control header
use Rack::CanonicalHost, 'example.com', cache_expiry: 'no-cache'
```