### PR TITLE
Add Cache-Control support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+  * Add `:cache_control` option ([Pete Nicholls][Aupajo])
+
 ## 0.2.1 (2016-03-28)
 
   * Relax Rack dependency to allow for Rack 2 ([Tyler Ewing][zoso10])
@@ -57,6 +61,7 @@
 
   * Initial release ([Tyler Hunt][tylerhunt])
 
+[Aupajo]: http://github.com/Aupajo
 [finack]: http://github.com/finack
 [firedev]: http://github.com/firedev
 [jcarbo]: http://github.com/jcarbo

--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ use Rack::CanonicalHost, 'example.com', if: /.*\.example\.com/
 use Rack::CanonicalHost, 'example.ru', if: /.*\.example\.ru/
 ```
 
+To avoid browsers indefinitely caching a 301 redirect, it's a sensible idea to
+set an expiry on each redirect, to hedge against the chance you need to change
+that redirect in the future.
+
+By default
+
+```ruby
+# Browsers will cache host redirects for up to one hour
+use Rack::CanonicalHost, 'example.com'
+
+# Browsers will cache host redirects for up to 42 seconds
+use Rack::CanonicalHost, 'example.com', cache_expiry: 42
+
+# Browsers will cache host redirects indefinitely (not recommended)
+use Rack::CanonicalHost, 'example.com', cache_expiry: false
+
+# Specify a custom value for the Cache-Control header
+use Rack::CanonicalHost, 'example.com', cache_expiry: 'no-cache'
+```
+
 ## Contributing
 
   1. Fork it

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ use Rack::CanonicalHost, 'example.com', cache_control: 'no-cache'
 Thanks to the following people who have contributed patches or helpful
 suggestions:
 
+  * [Pete Nicholls](https://github.com/Aupajo)
   * [Tyler Ewing](https://github.com/zoso10)
   * [Thomas Maurer](https://github.com/tma)
   * [Jeff Carbonella](https://github.com/jcarbo)

--- a/README.md
+++ b/README.md
@@ -95,24 +95,21 @@ use Rack::CanonicalHost, 'example.com', if: /.*\.example\.com/
 use Rack::CanonicalHost, 'example.ru', if: /.*\.example\.ru/
 ```
 
-To avoid browsers indefinitely caching a 301 redirect, it's a sensible idea to
-set an expiry on each redirect, to hedge against the chance you need to change
-that redirect in the future.
+### Cache-Control
 
-By default
+To avoid browsers indefinitely caching a `301` redirect, it’s a sensible idea
+to set an expiry on each redirect, to hedge against the chance you may need to
+change that redirect in the future.
 
-```ruby
-# Browsers will cache host redirects for up to one hour
+``` ruby
+# Leave caching up to the browser (which could cache it indefinitely):
 use Rack::CanonicalHost, 'example.com'
 
-# Browsers will cache host redirects for up to 42 seconds
-use Rack::CanonicalHost, 'example.com', cache_expiry: 42
+# Cache the redirect for up to an hour:
+use Rack::CanonicalHost, 'example.com', cache_control: 'max-age=3600'
 
-# Browsers will cache host redirects indefinitely (not recommended)
-use Rack::CanonicalHost, 'example.com', cache_expiry: false
-
-# Specify a custom value for the Cache-Control header
-use Rack::CanonicalHost, 'example.com', cache_expiry: 'no-cache'
+# Prevent caching of redirects:
+use Rack::CanonicalHost, 'example.com', cache_control: 'no-cache'
 ```
 
 ## Contributing

--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -35,6 +35,10 @@ describe Rack::CanonicalHost do
         expect(inner_app).to_not receive(:call)
         subject
       end
+
+      it 'includes a cache expiry' do
+        expect(subject).to have_header('Cache-Control').with('max-age=3600')
+      end
     end
   end
 
@@ -132,6 +136,34 @@ describe Rack::CanonicalHost do
         it { should_not be_redirect }
       end
 
+    end
+
+    context 'with a :cache_expiry option' do
+      let(:url) { 'http://subdomain.example.net/full/path' }
+
+      context 'that is a number' do
+        let(:app) { build_app('example.com', :cache_expiry => 42) }
+
+        it 'is treated as the max-age value' do
+          expect(subject).to have_header('Cache-Control').with('max-age=42')
+        end
+      end
+
+      context 'that is a string' do
+        let(:app) { build_app('example.com', :cache_expiry => 'no-cache') }
+
+        it 'passes the value to the Cache-Control header' do
+          expect(subject).to have_header('Cache-Control').with('no-cache')
+        end
+      end
+
+      context 'that is false' do
+        let(:app) { build_app('example.com', :cache_expiry => false) }
+
+        it 'disables the Cache-Control header' do
+          expect(subject).not_to have_header('Cache-Control')
+        end
+      end
     end
 
     context 'with a block' do

--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -36,8 +36,8 @@ describe Rack::CanonicalHost do
         subject
       end
 
-      it 'includes a cache expiry' do
-        expect(subject).to have_header('Cache-Control').with('max-age=3600')
+      it 'does not include a Cache-Control header' do
+        expect(subject).to_not have_header('Cache-Control')
       end
     end
   end
@@ -138,31 +138,31 @@ describe Rack::CanonicalHost do
 
     end
 
-    context 'with a :cache_expiry option' do
+    context 'with a :cache_control option' do
       let(:url) { 'http://subdomain.example.net/full/path' }
 
-      context 'that is a number' do
-        let(:app) { build_app('example.com', :cache_expiry => 42) }
+      context 'with a max-age value' do
+        let(:app) { build_app('example.com', :cache_control => 'max-age=3600') }
 
-        it 'is treated as the max-age value' do
-          expect(subject).to have_header('Cache-Control').with('max-age=42')
-        end
+        it { expect(subject).to have_header('Cache-Control').with('max-age=3600') }
       end
 
-      context 'that is a string' do
-        let(:app) { build_app('example.com', :cache_expiry => 'no-cache') }
+      context 'with a no-cache value' do
+        let(:app) { build_app('example.com', :cache_control => 'no-cache') }
 
-        it 'passes the value to the Cache-Control header' do
-          expect(subject).to have_header('Cache-Control').with('no-cache')
-        end
+        it { expect(subject).to have_header('Cache-Control').with('no-cache') }
       end
 
-      context 'that is false' do
-        let(:app) { build_app('example.com', :cache_expiry => false) }
+      context 'with a false value' do
+        let(:app) { build_app('example.com', :cache_control => false) }
 
-        it 'disables the Cache-Control header' do
-          expect(subject).not_to have_header('Cache-Control')
-        end
+        it { expect(subject).to_not have_header('Cache-Control') }
+      end
+
+      context 'with a nil value' do
+        let(:app) { build_app('example.com', :cache_control => false) }
+
+        it { expect(subject).to_not have_header('Cache-Control') }
       end
     end
 

--- a/spec/support/matchers/have_header.rb
+++ b/spec/support/matchers/have_header.rb
@@ -1,0 +1,52 @@
+module HaveHeader
+  class Matcher
+    attr :headers
+    attr :expected_header
+    attr :expected_value
+
+    def initialize(expected_header)
+      @expected_header = expected_header
+    end
+
+    def matches?(response)
+      _, @headers, _ = response
+
+      if expected_value
+        actual_header == expected_value
+      else
+        actual_header
+      end
+    end
+
+    def with(expected_value)
+      @expected_value = expected_value
+      self
+    end
+
+    def actual_header
+      headers[expected_header]
+    end
+
+    def description
+      sentence = "have header #{expected_header.inspect}"
+      sentence << " with #{expected_value.inspect}" if expected_value
+      sentence << ", got:\n #{headers.inspect}"
+    end
+
+    def failure_message
+      "Expected response to #{description}"
+    end
+
+    def failure_message_when_negated
+      "Did not expect response to #{description}"
+    end
+  end
+
+  def have_header(name)
+    Matcher.new(name)
+  end
+end
+
+RSpec.configure do |config|
+  config.include(HaveHeader)
+end


### PR DESCRIPTION
Add a new `:cache_control` option for setting the `Cache-Control` header when redirecting to allow the caching of the redirect to be…controlled. This can be especially important with `301` redirects which some browsers cache indefinitely.

This is based on the work of @Aupajo in #41. I've altered it slightly to remove the `Fixnum` form which required a type check, and to avoid setting a default value, which would break backwards compatibility. I _am_ open to setting a default value in a future release, but I'd like to see this proven before switching that on.