### PR TITLE
Support regex for the ignore option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Now, the middleware will only be used if a canonical host has been defined.
 ### Options
 
 If you'd like the middleware to ignore certain hosts, use the `:ignore`
-option:
+option, it accepts string, regexp or an array.
 
 ``` ruby
 use Rack::CanonicalHost, 'example.com', ignore: ['api.example.com']

--- a/lib/rack/canonical_host/redirect.rb
+++ b/lib/rack/canonical_host/redirect.rb
@@ -62,7 +62,10 @@ module Rack
       end
 
       def ignored?
-        ignore.include?(request_uri.host)
+        return false if ignore.empty?
+
+        ignore.include?(request_uri.host) ||
+          any_match?(ignore, request_uri.host)
       end
 
       def known?

--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -110,8 +110,26 @@ RSpec.describe Rack::CanonicalHost do
       include_context 'a matching request'
     end
 
-    context 'with :ignore option' do
+    context 'with :ignore string option' do
       let(:app) { build_app('example.com', :ignore => 'example.net') }
+
+      include_context 'a matching request'
+      include_context 'a non-matching request'
+
+      context 'with a request to an ignored host' do
+        let(:url) { 'http://example.net/full/path' }
+
+        it { should_not be_redirect }
+
+        it 'calls the inner app' do
+          expect(inner_app).to receive(:call).with(env)
+          call_app
+        end
+      end
+    end
+
+    context 'with :ignore regex option' do
+      let(:app) { build_app('example.com', :ignore => /ex.*\.net/) }
 
       include_context 'a matching request'
       include_context 'a non-matching request'


### PR DESCRIPTION
Why:
- As a developer I want to ignore domains via a regexp so that I can use
  this gem for a site that should allow subdomains.

This change addresses the need by:
- Add tests for using a regex with the ignore option.
- Add documentation in the README.md.
- Update the Redirect class to allow regex to be used for the ignore
  option.
