### PR TITLE
Remove unmaintained Ruby versions from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,6 @@ gemfile:
   - gemfiles/rack_2.0.gemfile
 
 rvm:
-  - 2.0.0
-  - 2.1.10
   - 2.2.7
   - 2.3.4
   - 2.4.1
-
-matrix:
-  exclude:
-    - rvm: 2.0.0
-      gemfile: gemfiles/rack_2.0.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rack_2.0.gemfile


### PR DESCRIPTION
The Ruby core team discontinued support of any kind for [Ruby 2.0](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/) on 2016-02-24 and [Ruby 2.1](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/) on 2017-04-01.