### PR TITLE
gemspec: Drop unused directives

### DIFF
--- a/rack-canonical-host.gemspec
+++ b/rack-canonical-host.gemspec
@@ -14,7 +14,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.0'
 
   gem.files = `git ls-files`.split($\)
-  gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 end


### PR DESCRIPTION
This gem exposes no executables, and the test_files directive is not used.