### PR TITLE
Explicitly handle malformed requests that result in Addressable::URI::InvalidURIError

### DIFF
--- a/lib/rack/canonical_host/redirect.rb
+++ b/lib/rack/canonical_host/redirect.rb
@@ -26,6 +26,8 @@ module Rack
       def canonical?
         return true unless enabled?
         known? || ignored?
+      rescue Addressable::URI::InvalidURIError
+        return true
       end
 
       def response


### PR DESCRIPTION
I noticed an `Addressable::URI::InvalidURIError`exception in my app using `rack-canonical-host` the other day, and ultimately tracked this down to a malformed request.

Since `rack-canonical-host` uses the parsed request to write the redirect, I don't know that it should do much more than not try to redirect malformed requests.