### PR TITLE
fix: return 400 if uri is bad

### DIFF
--- a/lib/rack/canonical_host.rb
+++ b/lib/rack/canonical_host.rb
@@ -20,6 +20,8 @@ module Rack
       else
         redirect.response
       end
+    rescue Addressable::URI::InvalidURIError
+      [400, { Rack::CONTENT_TYPE => "text/plain", Rack::CONTENT_LENGTH => "0" }, []]
     end
 
   protected

--- a/lib/rack/canonical_host.rb
+++ b/lib/rack/canonical_host.rb
@@ -15,13 +15,13 @@ module Rack
       host = evaluate_host(env)
       redirect = Redirect.new(env, host, options)
 
-      if redirect.canonical?
-        app.call(env)
-      else
-        redirect.response
+      begin
+        return redirect.response unless redirect.canonical?
+      rescue Addressable::URI::InvalidURIError
+        return [400, { Rack::CONTENT_TYPE => "text/plain", Rack::CONTENT_LENGTH => "0" }, []]
       end
-    rescue Addressable::URI::InvalidURIError
-      [400, { Rack::CONTENT_TYPE => "text/plain", Rack::CONTENT_LENGTH => "0" }, []]
+
+      app.call(env)
     end
 
   protected

--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -98,6 +98,21 @@ RSpec.describe Rack::CanonicalHost do
 
         it_behaves_like 'a non-matching request'
       end
+
+      context 'which is an invalid uri' do
+        let(:headers) { { 'HTTP_X_FORWARDED_HOST' => '[${jndi:ldap://172.16.26.190:52314/nessus}]/' } }
+
+        it { should_not be_redirect }
+
+        it { expect(response[0]).to be 400 }
+
+        it 'does not call the inner app' do
+          expect(inner_app).to_not receive(:call)
+          call_app
+        end
+
+        it { expect(response).to_not have_header('cache-control') }
+      end
     end
 
     context 'without a host' do

--- a/spec/rack/canonical_host_spec.rb
+++ b/spec/rack/canonical_host_spec.rb
@@ -84,6 +84,20 @@ RSpec.describe Rack::CanonicalHost do
       end
     end
 
+
+    context 'when the app happens to have an invalid uri error' do
+      before do
+        allow(inner_app)
+          .to receive(:call)
+          .with(env)
+          .and_raise(Addressable::URI::InvalidURIError)
+      end
+
+      it 'explodes as expected' do
+        expect { call_app }.to raise_error(Addressable::URI::InvalidURIError)
+      end
+    end
+
     context 'with an X-Forwarded-Host' do
       let(:url) { 'http://proxy.test/full/path' }
 


### PR DESCRIPTION
I still think it could be possible to redirect these, but ultimately a bad uri is a sign that something weird is going on that is probably an edge case so it should be perfectly fine to just return a 400.

Resolves #68
Closes #64