### PR TITLE
Evaluate host block only if the return value is used

### DIFF
--- a/lib/rack/canonical_host.rb
+++ b/lib/rack/canonical_host.rb
@@ -17,8 +17,7 @@ module Rack
 
       return request.bad_request_response unless request.valid?
 
-      host = evaluate_host(env)
-      redirect = Redirect.new(env, host, options)
+      redirect = Redirect.new(env, host, options, &block)
 
       if redirect.canonical?
         app.call(env)
@@ -33,11 +32,5 @@ module Rack
     attr_accessor :host
     attr_accessor :options
     attr_accessor :block
-
-  private
-
-    def evaluate_host(env)
-      block and block.call(env) or host
-    end
   end
 end


### PR DESCRIPTION
Currently, the host block is evaluated even if the return value isn't used, e.g., when the `if` condition returns false. I think this behavior is surprising. I spent a significant amount of time on debugging an issue which I thought was related to the condition logic until I discovered this.